### PR TITLE
Update UML diagrams with updated DeleteSequenceDiagram

### DIFF
--- a/docs/diagrams/DeleteSequenceDiagram.puml
+++ b/docs/diagrams/DeleteSequenceDiagram.puml
@@ -14,10 +14,10 @@ box Model MODEL_COLOR_T1
 participant "m:Model" as Model MODEL_COLOR
 end box
 
-[-> LogicManager : execute("delete 1")
+[-> LogicManager : execute("delete E0001")
 activate LogicManager
 
-LogicManager -> AddressBookParser : parseCommand("delete 1")
+LogicManager -> AddressBookParser : parseCommand("delete E0001")
 activate AddressBookParser
 
 create DeleteCommandParser
@@ -27,7 +27,7 @@ activate DeleteCommandParser
 DeleteCommandParser --> AddressBookParser
 deactivate DeleteCommandParser
 
-AddressBookParser -> DeleteCommandParser : parse("1")
+AddressBookParser -> DeleteCommandParser : parse("E0001")
 activate DeleteCommandParser
 
 create DeleteCommand
@@ -49,7 +49,14 @@ deactivate AddressBookParser
 LogicManager -> DeleteCommand : execute(m)
 activate DeleteCommand
 
-DeleteCommand -> Model : deletePerson(1)
+DeleteCommand -> Model : getFilteredPersonList()
+activate Model
+Model --> DeleteCommand : lastShownList
+deactivate Model
+
+DeleteCommand -> DeleteCommand : find person with employeeId "E0001"
+
+DeleteCommand -> Model : deletePerson(personToDelete)
 activate Model
 
 Model --> DeleteCommand


### PR DESCRIPTION
This pull request updates the `DeleteSequenceDiagram.puml` to reflect a change in the delete command's behavior: instead of deleting a person by their index, the system now deletes by employee ID. The sequence diagram has been modified to show the new flow, including how the employee is found and deleted.

**Delete command flow updated to use employee ID:**

* Changed the command input and parsing from using an index (e.g., `"delete 1"`) to using an employee ID (e.g., `"delete E0001"`), updating interactions between `LogicManager`, `AddressBookParser`, and `DeleteCommandParser` accordingly. 
* Modified the sequence so that `DeleteCommand` retrieves the filtered person list from `Model`, finds the person with the specified employee ID, and then deletes that person, instead of deleting by index.