### PR TITLE
Increase default window size and fix scaling issue

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -353,7 +353,7 @@
 
 .organization-panel {
     -fx-background-color: gainsboro;
-    -fx-padding: 1 3 1 3;
+    -fx-padding: 1;
     -fx-border-radius: 10;
     -fx-padding: 14 14;
 }
@@ -369,5 +369,6 @@
     -fx-font-size: 12pt;
     -fx-fill: black;
     -fx-underline: false;
+    -fx-font-family: "Courier New";
 }
 

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -49,7 +49,7 @@
         <HBox HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS" styleClass="pane-with-border">
           <StackPane fx:id="organizationPanelPlaceholder" styleClass="pane-with-border" minWidth="220">
             <padding>
-              <Insets top="5" right="10" bottom="5" left="10" />
+              <Insets top="5" right="5" bottom="5" left="5" />
             </padding>
           </StackPane>
           <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" maxWidth="Infinity" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">

--- a/src/main/resources/view/OrganizationPanel.fxml
+++ b/src/main/resources/view/OrganizationPanel.fxml
@@ -5,12 +5,8 @@
 <?import javafx.scene.layout.HBox?>
 
 <?import javafx.scene.text.Text?>
-<?import javafx.geometry.Insets?>
 <StackPane styleClass="organization-panel" xmlns="http://javafx.com/javafx/17"
            xmlns:fx="http://javafx.com/fxml/1">
-    <padding>
-        <Insets top="10" right="10" bottom="10" left="10" />
-    </padding>
     <Text fx:id="organizationTitle" styleClass="title" text="Organization Hierarchy" StackPane.alignment="TOP_CENTER"/>
     <Text fx:id="organizationDetails" styleClass="hierarchy-text"/>
     <Label fx:id="organizationPanelPlaceholder" styleClass="result-display" HBox.hgrow="ALWAYS" />


### PR DESCRIPTION
- Fix scaling issue where bottom would show white when the window was resized
- Increase command output box to show more text
- Change font of organization hierarchy panel to make it Mac-friendly

<img width="779" height="970" alt="image" src="https://github.com/user-attachments/assets/f6e0c761-10c4-437f-8798-c116ef52a6ce" />