### PR TITLE
Br fix delete command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -25,8 +25,7 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person:\n%1$s";
     public static final String MESSAGE_PERSON_NOT_FOUND = "No person found with employee ID: %1$s";
-    public static final String MESSAGE_PERSON_IN_TEAM =
-            "Cannot delete person %1$s because they are a member of these teams: %2$s";
+    public static final String MESSAGE_PERSON_IN_TEAM = "Cannot delete %1$s as they are a member of: %2$s";
 
     private final String employeeId;
 


### PR DESCRIPTION
This pull request updates the `DeleteCommand` logic to prevent deleting a person who is still a member of one or more teams. If a user attempts to delete such a person, a clear error message is shown listing the teams the person belongs to.

**Delete command behavior update:**

* Added a check in `DeleteCommand` to prevent deletion if the person is a member of any teams, returning a descriptive error message listing the relevant teams.
* Introduced a new error message constant `MESSAGE_PERSON_IN_TEAM` for this scenario.
* Imported `Collectors.toList` to support formatting the list of team IDs in the error message.