### PR TITLE
Set teams to be initialized with upper case names

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -185,7 +185,7 @@ Warning:
 * If none of the specified tags exist on the person, the command will fail with an error message listing the non-existent tags. However, if at least one tag exists, valid tags will be removed and a warning will show which tags were not found.
 
 ### Creating a team: `create-team`
-Adds a team to the address book.
+Adds a team to the address book. All team names are automatically set to Upper Case format.
 
 Format: `create-team TEAM_NAME TEAM_LEADER_ID`
 

--- a/src/main/java/seedu/address/model/team/TeamName.java
+++ b/src/main/java/seedu/address/model/team/TeamName.java
@@ -23,8 +23,9 @@ public record TeamName(String teamName) {
      *
      * @param teamName A valid name.
      */
-    public TeamName {
+    public TeamName(String teamName) {
         requireNonNull(teamName);
+        this.teamName = teamName.toUpperCase();
         checkArgument(isValidTeamName(teamName), MESSAGE_CONSTRAINTS);
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedTeam.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTeam.java
@@ -42,7 +42,7 @@ class JsonAdaptedTeam {
      */
     public JsonAdaptedTeam(Team source) {
         id = source.getId();
-        name = source.getTeamName().teamName();
+        name = source.getTeamName().teamName().toUpperCase();
         leaderId = source.getLeaderId();
         if (source.getMembers() != null) {
             members.addAll(source.getMembers());

--- a/src/test/java/seedu/address/logic/commands/CreateTeamCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CreateTeamCommandTest.java
@@ -29,10 +29,10 @@ public class CreateTeamCommandTest {
         CreateTeamCommand cmd = new CreateTeamCommand("Systems", "E0001");
         CommandResult result = cmd.execute(model);
 
-        assertEquals(String.format(CreateTeamCommand.MESSAGE_SUCCESS, "Systems"),
+        assertEquals(String.format(CreateTeamCommand.MESSAGE_SUCCESS, "SYSTEMS"),
                 result.getFeedbackToUser());
         assertTrue(model.getAddressBook().getTeamList().stream()
-                .anyMatch(t -> "Systems".equals(t.getTeamName().teamName())
+                .anyMatch(t -> "SYSTEMS".equals(t.getTeamName().teamName())
                         && "E0001".equals(t.getLeaderId())));
     }
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -150,7 +150,7 @@ public class ModelManagerTest {
         // find team with same id and verify updated name
         boolean foundEditedName = model.getAddressBook().getTeamList().stream()
                 .filter(t -> "T0001".equals(t.getId()))
-                .anyMatch(t -> "CoreRenamed".equals(t.getTeamName().teamName()));
+                .anyMatch(t -> "CORERENAMED".equals(t.getTeamName().teamName()));
         assertTrue(foundEditedName);
     }
 

--- a/src/test/java/seedu/address/model/team/TeamTest.java
+++ b/src/test/java/seedu/address/model/team/TeamTest.java
@@ -118,8 +118,8 @@ public class TeamTest {
         // sanity checks using TypicalTeams fixtures
         assertEquals("QA", QA.getTeamName().teamName());
         assertTrue(CORE.getMembers().contains("E0001"));
-        assertEquals("Backend", BACKEND.getTeamName().teamName());
-        assertEquals("Frontend", FRONTEND.getTeamName().teamName());
+        assertEquals("BACKEND", BACKEND.getTeamName().teamName());
+        assertEquals("FRONTEND", FRONTEND.getTeamName().teamName());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/team/UniqueTeamListTest.java
+++ b/src/test/java/seedu/address/model/team/UniqueTeamListTest.java
@@ -54,7 +54,7 @@ public class UniqueTeamListTest {
         Team root = new Team("T1", new TeamName("Root"));
         list.add(root);
 
-        String expected = "Root #T1 Members: []\n";
+        String expected = "ROOT #T1 Members: []\n";
         assertEquals(expected, list.getHierarchyString());
     }
 
@@ -117,9 +117,9 @@ public class UniqueTeamListTest {
 
         String expected =
                 """
-                        Root1 #T1 Members: []
-                        └── Child1 #T2 Members: []
-                        Root2 #T3 Members: []
+                        ROOT1 #T1 Members: []
+                        └── CHILD1 #T2 Members: []
+                        ROOT2 #T3 Members: []
                         """;
 
         assertEquals(expected, list.getHierarchyString());

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -64,7 +64,7 @@ public class JsonSerializableAddressBookTest {
         List<Team> teams = converted.getTeamList();
 
         assertEquals(1, teams.size());
-        assertEquals("Core", teams.get(0).getTeamName().teamName());
+        assertEquals("CORE", teams.get(0).getTeamName().teamName());
     }
 
     @Test


### PR DESCRIPTION
- When initializing teams, set them to uppercase
- Updated UG to state that team names are capitalized
- Updated test cases to check for capitalized team names
- Resolves issue #242