### PR TITLE
Fix id increment for add and import

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -14,7 +14,6 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.CreateTeamCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.logic.parser.AddCommandParser;
 import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
@@ -54,17 +53,7 @@ public class LogicManager implements Logic {
         addressBookParser = new AddressBookParser();
 
         // Initialize team and person ID counter
-        List<Person> persons = model.getAddressBook().getPersonList();
         List<Team> teams = model.getAddressBook().getTeamList();
-        if (!persons.isEmpty()) {
-            long maxId = persons.stream()
-                    .map(Person::id)
-                    .filter(id -> id.startsWith("E"))
-                    .mapToLong(id -> Long.parseLong(id.substring(1)))
-                    .max()
-                    .orElse(0);
-            AddCommandParser.setNextId(maxId + 1);
-        }
 
         if (!teams.isEmpty()) {
             long maxTeamId = teams.stream()
@@ -84,20 +73,22 @@ public class LogicManager implements Logic {
 
         CommandResult commandResult;
         Command command = addressBookParser.parseCommand(commandText);
-        commandResult = command.execute(model);
-
-        // Only log commands that modify state
-        if (shouldLogCommand(command)) {
-            String action = extractAction(command);
-            String details = generateDetails(commandResult);
-            model.getAuditLog().addEntry(action, details, LocalDateTime.now());
-        }
-
+        ReadOnlyAddressBook backupAddressBook = model.getAddressBook();
         try {
+            commandResult = command.execute(model);
+
+            // Only log commands that modify state
+            if (shouldLogCommand(command)) {
+                String action = extractAction(command);
+                String details = generateDetails(commandResult);
+                model.getAuditLog().addEntry(action, details, LocalDateTime.now());
+            }
             storage.saveAddressBook(model.getAddressBook());
         } catch (AccessDeniedException e) {
+            model.setAddressBook(backupAddressBook);
             throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
         } catch (IOException ioe) {
+            model.setAddressBook(backupAddressBook);
             throw new CommandException(String.format(FILE_OPS_ERROR_FORMAT, ioe.getMessage()), ioe);
         }
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -7,6 +7,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_GITHUB;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -56,8 +59,29 @@ public class AddCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
-        model.addPerson(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
+        Set<Long> usedIds = model.getAddressBook().getPersonList().stream()
+                .map(Person::id).filter(id -> id.startsWith("E"))
+                .map(id -> Long.parseLong(id.substring(1)))
+                .collect(Collectors.toSet());
+
+        long newId = findNextAvailableId(usedIds);
+        Person personWithId = new Person(String.format("E%04d", newId),
+                toAdd.name(), toAdd.phone(), toAdd.email(),
+                toAdd.address(), toAdd.gitHubUsername(), toAdd.tags());
+        model.addPerson(personWithId);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(personWithId)));
+    }
+
+    /**
+     * Finds the next available ID that doesn't exist in the addressbook.
+     * Scans sequentially from 1 until a gap is found.
+     */
+    public static long findNextAvailableId(Set<Long> usedIds) {
+        long id = 1;
+        while (usedIds.contains(id)) {
+            id++;
+        }
+        return id;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -5,7 +5,9 @@ import static java.util.Objects.requireNonNull;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.DataLoadingException;
@@ -66,10 +68,26 @@ public class ImportCommand extends Command {
      * @param list a list of Person objects
      */
     private void addImportedPersons(Model model, List<Person> list) {
-        // Add each imported person into the model iteratively.
+        Set<Long> usedIds = model.getAddressBook().getPersonList().stream()
+                .map(Person::id)
+                .filter(id -> id.startsWith("E"))
+                .map(id -> Long.parseLong(id.substring(1)))
+                .collect(Collectors.toSet());
+
         for (Person person : list) {
             try {
-                model.addPerson(person);
+                long numericId = Long.parseLong(person.id().substring(1));
+                if (usedIds.contains(numericId)) {
+                    long newId = AddCommand.findNextAvailableId(usedIds);
+                    Person personWithId = new Person(String.format("E%04d", newId),
+                            person.name(), person.phone(), person.email(),
+                            person.address(), person.gitHubUsername(), person.tags());
+                    model.addPerson(personWithId);
+                    usedIds.add(newId);
+                } else {
+                    model.addPerson(person);
+                    usedIds.add(numericId);
+                }
             } catch (Exception ex) {
                 storageLogger.info("Skipping person during import: " + person + " (" + ex.getMessage() + ")");
             }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -68,7 +68,7 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         Set<Tag> tagList = new HashSet<>();
 
-        Person person = new Person(String.format("E%04d", nextId++), name, phone, email, address,
+        Person person = new Person(String.format("E%04d", 0), name, phone, email, address,
                 gitHubUsername, tagList);
         return new AddCommand(person);
     }
@@ -79,22 +79,6 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
-    /**
-     * Sets the next ID based on the highest existing ID in the address book.
-     * Should be called when the application starts.
-     */
-    public static void setNextId(long id) {
-        nextId = id;
-    }
-
-    /**
-     * Gets the current next ID value.
-     * Used for testing purposes.
-     */
-    public static long getNextId() {
-        return nextId;
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -1,13 +1,13 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -27,15 +27,19 @@ public class AddCommandIntegrationTest {
     }
 
     @Test
-    public void execute_newPerson_success() {
-        Person validPerson = new PersonBuilder().build();
+    public void execute_newPerson_success() throws CommandException {
+        Person validPerson = new PersonBuilder().withId(0).build();
 
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-        expectedModel.addPerson(validPerson);
+        // Execute command to assign ID
+        new AddCommand(validPerson).execute(model);
 
-        assertCommandSuccess(new AddCommand(validPerson), model,
-                String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
-                expectedModel);
+        // Verify person was added with valid ID
+        Person addedPerson = model.getFilteredPersonList().stream()
+                .filter(p -> p.name().equals(validPerson.name()))
+                .findFirst()
+                .orElseThrow();
+
+        assertTrue(addedPerson.id().matches("E\\d{4}"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -9,7 +9,6 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.function.Predicate;
 
@@ -17,7 +16,6 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
@@ -38,13 +36,14 @@ public class AddCommandTest {
     @Test
     public void execute_personAcceptedByModel_addSuccessful() throws Exception {
         ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
-        Person validPerson = new PersonBuilder().build();
+        Person validPerson = new PersonBuilder().withId(0).build();
 
         CommandResult commandResult = new AddCommand(validPerson).execute(modelStub);
 
-        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
-                commandResult.getFeedbackToUser());
-        assertEquals(Arrays.asList(validPerson), modelStub.personsAdded);
+        // Verify the added person has a valid ID
+        Person addedPerson = modelStub.personsAdded.get(0);
+        assertTrue(addedPerson.id().matches("E\\d{4}"));
+        assertTrue(commandResult.getFeedbackToUser().contains("New person added"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
@@ -34,7 +33,6 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
@@ -50,32 +48,14 @@ import seedu.address.testutil.PersonBuilder;
 public class AddCommandParserTest {
     private AddCommandParser parser = new AddCommandParser();
 
-    @BeforeEach
-    public void setUp() {
-        // Reset nextId before each test to ensure consistent behavior
-        AddCommandParser.setNextId(1);
-    }
-
-    private static long getNextId() {
-        return AddCommandParser.getNextId();
-    }
-
     @Test
     public void parse_allFieldsPresent_success() {
-        Person expectedPerson = new PersonBuilder(BOB).withId(getNextId()).withTags().build();
+        // Person will have placeholder ID
+        Person expectedPerson = new PersonBuilder(BOB).withId(0).withTags().build();
 
-        // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + GITHUBUSERNAME_DESC_BOB,
+                        + ADDRESS_DESC_BOB + GITHUBUSERNAME_DESC_BOB,
                 new AddCommand(expectedPerson));
-
-
-        // multiple tags - all accepted
-        Person expectedPersonMultipleTags = new PersonBuilder(BOB)
-                .withId(getNextId()).withTags().build();
-        assertParseSuccess(parser,
-                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + GITHUBUSERNAME_DESC_BOB,
-                new AddCommand(expectedPersonMultipleTags));
     }
 
     @Test
@@ -146,8 +126,7 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_optionalFieldsMissing_success() {
-        // zero tags
-        Person expectedPerson = new PersonBuilder(AMY).withTags().withId(getNextId()).build();
+        Person expectedPerson = new PersonBuilder(AMY).withTags().withId(0).build();
         assertParseSuccess(parser,
                 NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + GITHUBUSERNAME_DESC_AMY,
                 new AddCommand(expectedPerson));
@@ -212,7 +191,7 @@ public class AddCommandParserTest {
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + GITHUBUSERNAME_DESC_BOB,
+                        + ADDRESS_DESC_BOB + GITHUBUSERNAME_DESC_BOB,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 
@@ -233,49 +212,9 @@ public class AddCommandParserTest {
     @Test
     public void parse_githubUsernameMissing_success() {
         // GitHub username prefix missing
-        Person expectedPerson = new PersonBuilder(AMY).withGitHubUsername("").withTags().withId(getNextId()).build();
+        Person expectedPerson = new PersonBuilder(AMY).withGitHubUsername("").withTags().withId(0).build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,
                 new AddCommand(expectedPerson));
-    }
-
-
-    @Test
-    public void setNextId_validId_success() {
-        AddCommandParser.setNextId(100);
-        assertEquals(100, AddCommandParser.getNextId());
-    }
-
-    @Test
-    public void setNextId_afterMultipleAdds_incrementsCorrectly() throws Exception {
-        AddCommandParser.setNextId(1);
-
-        // Parse first person
-        parser.parse(NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + GITHUBUSERNAME_DESC_BOB);
-        assertEquals(2, AddCommandParser.getNextId());
-
-        // Parse second person
-        parser.parse(NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
-                + ADDRESS_DESC_AMY + GITHUBUSERNAME_DESC_AMY);
-        assertEquals(3, AddCommandParser.getNextId());
-    }
-
-    @Test
-    public void setNextId_largeValue_success() {
-        AddCommandParser.setNextId(1007);
-        assertEquals(1007, AddCommandParser.getNextId());
-
-        // Next person should get E1007
-        Person expectedPerson = new PersonBuilder(BOB)
-                .withTags()
-                .withId(1007)
-                .build();
-
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                        + ADDRESS_DESC_BOB + GITHUBUSERNAME_DESC_BOB,
-                new AddCommand(expectedPerson));
-
-        assertEquals(1008, AddCommandParser.getNextId());
     }
 
 }


### PR DESCRIPTION
This pull request refactors the way person IDs are assigned and managed in the application, moving away from a global `nextId` counter to a dynamic approach that finds the next available ID when adding or importing persons. It also updates error handling in the logic layer to ensure model consistency during storage failures, and removes related legacy code and tests. The most important changes are grouped below.

### Person ID Assignment and Management

* Replaced the global `nextId` counter in `AddCommandParser` with a dynamic method: IDs are now assigned by scanning for the next available unused ID when adding a person (`findNextAvailableId` in `AddCommand`). This ensures IDs are always unique and sequential, even after deletions or imports.
* Updated `ImportCommand` to assign new IDs to imported persons if their ID conflicts with an existing one, using the same dynamic method.

### Error Handling and Model Consistency

* Improved error handling in `LogicManager`: if saving the address book fails due to permission or IO errors, the model is reverted to its previous state to prevent partial updates.

### Code Cleanup and Test Refactoring

* Removed all code and tests related to the legacy `nextId` counter, including static methods and reflection-based setup/teardown in tests.
* Updated unit and integration tests for `AddCommand` and `LogicManager` to verify that new persons are assigned valid, unique IDs, and removed any reliance on hardcoded or global ID state. 
